### PR TITLE
Only fail with no default when the answer is nil.

### DIFF
--- a/lib/hiera-puppet-helper/puppet.rb
+++ b/lib/hiera-puppet-helper/puppet.rb
@@ -77,7 +77,7 @@ class Puppet::Parser::Compiler
 
       answer = hiera.lookup(key, default, hiera_scope, override, :array)
 
-      raise(Puppet::ParseError, "Could not find data item #{key} in any Hiera data file and no default supplied") if answer.empty?
+      raise(Puppet::ParseError, "Could not find data item #{key} in any Hiera data file and no default supplied") if answer.nil?
 
       answer
     end
@@ -108,7 +108,7 @@ class Puppet::Parser::Compiler
 
       answer = hiera.lookup(key, default, hiera_scope, override, :hash)
 
-      raise(Puppet::ParseError, "Could not find data item #{key} in any Hiera data file and no default supplied") if answer.empty?
+      raise(Puppet::ParseError, "Could not find data item #{key} in any Hiera data file and no default supplied") if answer.nil?
 
       answer
     end
@@ -137,7 +137,7 @@ class Puppet::Parser::Compiler
 
       answer = hiera.lookup(key, default, hiera_scope, override, :array)
 
-      raise(Puppet::ParseError, "Could not find data item #{key} in any Hiera data file and no default supplied") if answer.empty?
+      raise(Puppet::ParseError, "Could not find data item #{key} in any Hiera data file and no default supplied") if answer.nil?
 
       method = Puppet::Parser::Functions.function(:include)
       send(method, answer)


### PR DESCRIPTION
When checking for .empty? in stead of .nil?, calls like this always fail the tests:

``` puppet
  $some_param = hiera_array('foo::bar', [])
```
